### PR TITLE
docs: add a11y note about prefers-reduced-motion status

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ npm run dev
 
 Open <http://localhost:3000>.
 
+> Note: prefers-reduced-motion is not yet fully implemented.
+
 ### Build for production
 
 ```bash


### PR DESCRIPTION
Acknowledges the known gap tracked in issue #4. No functional changes.